### PR TITLE
5 bug count function has incorrect column name in columndefinitions

### DIFF
--- a/src/sqlark/column_definition.py
+++ b/src/sqlark/column_definition.py
@@ -28,6 +28,8 @@ class ColumnDefinition:
         """
         if self.alias is None:
             self.alias = f"{self.table_name}.{self.name}"
+        elif self.alias and "." not in self.alias:
+            self.alias = f"{self.table_name}.{self.alias}"
 
     def column_name_from_alias(self) -> str:
         """

--- a/src/sqlark/column_definition.py
+++ b/src/sqlark/column_definition.py
@@ -29,14 +29,31 @@ class ColumnDefinition:
         if self.alias is None:
             self.alias = f"{self.table_name}.{self.name}"
 
+    def column_name_from_alias(self) -> str:
+        """
+        Extract the column name from the alias
+        If the alias is in the format "table_name.column_name", return "column_name"
+        Otherwise, return the alias as is
+        """
+        if self.alias and "." in self.alias:
+            return self.alias.split(".")[1]
+        if self.alias:
+            return self.alias
+        return self.name
+
     def format_with_alias(self) -> sql.Composed:
         """
-        Format the column definition with alias
+        Format the column definition with alias.
+        If no alias was provided, use table_name.column_name as the alias.
 
         :param self: Description
         :return: Description
         :rtype: Composed
         """
+
+        if not self.alias:
+            raise ValueError("Alias must be set for format_with_alias")
+
         if self.function:
             return sql.SQL("{} {}").format(
                 sql.SQL(self.function),

--- a/src/sqlark/column_definition.py
+++ b/src/sqlark/column_definition.py
@@ -45,11 +45,13 @@ class ColumnDefinition:
 
     def format_with_alias(self) -> sql.Composed:
         """
-        Format the column definition with alias.
-        If no alias was provided, use table_name.column_name as the alias.
+        Format the column definition with an alias.
 
-        :param self: Description
-        :return: Description
+        This method assumes that ``self.alias`` has already been set
+        (typically by ``__post_init__``). If ``alias`` is not set when this
+        method is called, a :class:`ValueError` is raised.
+
+        :return: A composed SQL expression selecting the column with its alias
         :rtype: Composed
         """
 

--- a/src/sqlark/response_formatters.py
+++ b/src/sqlark/response_formatters.py
@@ -10,6 +10,7 @@ Response formatters accept one required parameters and two optional parameters:
     command: Optional[SQLCommand] The command that generated the result set
 """
 
+import typing
 from collections import namedtuple
 from typing import List, Dict
 from sqlark.column_definition import ColumnDefinition
@@ -17,6 +18,10 @@ from sqlark.utilities import (
     decompose_row,
     build_dataclasses,
 )
+
+if typing.TYPE_CHECKING:
+    from sqlark.postgres_config import PostgresConfig
+    from sqlark.command import SQLCommand
 
 
 # Disable unused-argument warning for pg_config and command. These arguments exist for consistency
@@ -45,7 +50,9 @@ def decompose_dict_response_formatter(
 
 
 def object_response_formatter(
-    result_set: list[dict], pg_config=None, command=None
+    result_set: list[dict],
+    pg_config: "PostgresConfig | None" = None,
+    command: "SQLCommand | None" = None,
 ) -> list[object]:
     """
     Returns the result set as a list of objects

--- a/src/sqlark/select.py
+++ b/src/sqlark/select.py
@@ -26,15 +26,15 @@ class Select(SQLCommand):
         "_group_by",
     ]
 
-    def __init__(self, table_name):
+    def __init__(self, table_name: str):
         """
         Perpare a select query using table_name as the primary table
         """
         super().__init__()
-        self._table_name = table_name
-        self._distinct = None
-        self._join = None
-        self._where = None
+        self._table_name: str = table_name
+        self._distinct: sql.Composed | None = None
+        self._join: Join | None = None
+        self._where: Where | None = None
         self._order_by = None
         self._limit = None
         self._offset = None
@@ -59,7 +59,7 @@ class Select(SQLCommand):
 
         return col_defs
 
-    def get_columns(self, table_name, pg_config):
+    def get_columns(self, table_name: str, pg_config: PostgresConfig) -> sql.Composed:
         """The sql formatted columns to use building the query"""
         columns = get_columns_composed(table_name, pg_config)
 

--- a/src/sqlark/utilities.py
+++ b/src/sqlark/utilities.py
@@ -194,7 +194,10 @@ def build_dataclasses(
             continue
 
         fields = [
-            (c.name, data_type_to_field_type(c.data_type, c.is_nullable))
+            (
+                c.column_name_from_alias(),
+                data_type_to_field_type(c.data_type, c.is_nullable),
+            )
             for c in columns
         ]
         built_classes[class_name] = make_dataclass(class_name.title(), fields)

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -67,6 +67,23 @@ def test_count_06(pg_connection):
     )
     assert (
         count.to_sql(pg_connection).as_string(pg_connection).strip()
-        == 'SELECT COUNT(*) as "table1.count","table1"."c1" as "table1.c1",date_trunc(\'day\', created_at) "created_at_day" FROM "table1"    GROUP BY "table1"."c1",date_trunc(\'day\', created_at)'
+        == 'SELECT COUNT(*) as "table1.count","table1"."c1" as "table1.c1",date_trunc(\'day\', created_at) "table1.created_at_day" FROM "table1"    GROUP BY "table1"."c1",date_trunc(\'day\', created_at)'
     )
     assert count.get_params() == []
+
+    # Ensure that the column definitions are correct
+    col_defs = count.get_column_definitions(pg_connection)
+    assert "table1" in col_defs
+    cols = col_defs["table1"]
+    assert len(cols) == 3
+    assert cols[0].column_name_from_alias() == "count"
+    assert cols[0].function == "COUNT"
+    assert cols[0].alias == "table1.count"
+    assert cols[1].column_name_from_alias() == "c1"
+    assert cols[1].table_name == "table1"
+    assert cols[1].function is None
+    assert cols[1].alias == "table1.c1"
+    assert cols[2].column_name_from_alias() == "created_at_day"
+    assert cols[2].table_name == "table1"
+    assert cols[2].function == "date_trunc('day', created_at)"
+    assert cols[2].alias == "table1.created_at_day"

--- a/tests/test_response_formatters.py
+++ b/tests/test_response_formatters.py
@@ -3,7 +3,7 @@ from dataclasses import asdict
 from unittest import mock
 from pytest import mark
 from dataclasses import dataclass
-from sqlark import Select
+from sqlark import Select, Count
 from sqlark.utilities import ColumnDefinition
 from sqlark.response_formatters import (
     decompose_dict_response_formatter,
@@ -429,6 +429,19 @@ def test_object_response_formatter_response_to_insert(p1, pg_connection):
     )
     assert formatted_response[0].column_name == "value"
     assert formatted_response[0].column2 == "value2"
+
+
+def test_object_response_formatter_for_count(pg_connection):
+    """
+    Tests that the object response formatter can handle a count response
+    which does not have a table name in the response
+    """
+    response = [{"table_name.count": 5, "table_name.status": "active"}]
+    formatted_response = object_response_formatter(
+        response, pg_connection, Count("table_name").group_by("status")
+    )
+    assert formatted_response[0].count == 5
+    assert formatted_response[0].status == "active"
 
 
 @mock.patch(


### PR DESCRIPTION
Primary Changes:
* Alias is used as column name when building response data structures
* Alias is automatically pre-prended with table name if not provided

Secondary Changes:
* Additional type checking for data structures.